### PR TITLE
feature/stdlib-compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,14 +13,14 @@ PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
 [compat]
 DocStringExtensions = "0.9"
 JLD2 = "0.4"
-Pkg = "1"
+Pkg = "<0.0.1, 1"
 PyCall = "1"
 julia = "1"
 
 [extras]
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 SafeTestsets = "1bc83da4-3b8d-516f-aca4-4fe02f6d838f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [targets]
 test = ["Test", "SafeTestsets", "Logging"]

--- a/test/test_sets.jl
+++ b/test/test_sets.jl
@@ -12,7 +12,7 @@ This file loads common utilities and aggregates all other unit tests files.
 
 ## Load the modules into the current context
 using
-    Pkg,        # for rebuilding PyCall
+    # Pkg,        # for rebuilding PyCall
     PyCall,     # for PyObjects
     JLD2,       # for saving and loading
     PyCallJLD2  # this package
@@ -30,8 +30,8 @@ using
 # -----------------------------------------------------------------------------
 
 # Build the PyCall environment for all tests
-ENV["PYTHON"] = ""
-Pkg.build("PyCall")
+# ENV["PYTHON"] = ""
+# Pkg.build("PyCall")
 
 # Init the Python module the way that it would be loaded and stored in a Julia module
 const lm = PyNULL()


### PR DESCRIPTION
This PR adds a Pkg@0.0.0 compat entry for earlier versions of Julia that handle stdlib dependencies as being at versions 0.0.0. It also removes the use of Pkg in the unit tests to mitigate the missing overlap in other stdlib packages in deeper dependencies (i.e., a missing overlap between LinearAlgebra@0.0.0 and 1.4.0 in PyCall).