### PR TITLE
Include macOC and windows in test matrix

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,8 +19,8 @@ jobs:
           - "1"    # Latest Release
         os:
           - ubuntu-latest
-          # - macOS-latest
-          # - windows-latest
+          - macOS-latest
+          - windows-latest
         arch:
           - x64
           # - x86

--- a/test/test_sets.jl
+++ b/test/test_sets.jl
@@ -35,7 +35,8 @@ using
 
 # Init the Python module the way that it would be loaded and stored in a Julia module
 const lm = PyNULL()
-copy!(lm, pyimport_conda("sklearn.linear_model", "sklearn"))
+# copy!(lm, pyimport_conda("sklearn.linear_model", "sklearn"))
+copy!(lm, pyimport_conda("sklearn.linear_model", "scikit-learn"))
 
 @testset "PyCall Save and Load" begin
     # Create some PyObjects


### PR DESCRIPTION
This PR expands the automated tests to run on 64-bit macOS and Windows for both Julia LTS 1.6 and the latest stable version.